### PR TITLE
True stereo

### DIFF
--- a/examples/choice_demo.rs
+++ b/examples/choice_demo.rs
@@ -41,7 +41,9 @@ fn run_chooser(
             0 => {
                 let program = {
                     let program_table = program_table.lock().unwrap();
-                    console_choice_from("Change synth to", &program_table, |opt| opt.0.as_str())
+                    console_choice_from("Change synth to", &program_table.entries, |opt| {
+                        opt.0.as_str()
+                    })
                 };
                 midi_msgs.push(SynthMsg::program_change(program as u8, Speaker::Both));
             }

--- a/examples/just_tempered_demo.rs
+++ b/examples/just_tempered_demo.rs
@@ -2,8 +2,12 @@ use std::sync::{Arc, Mutex};
 
 use crossbeam_queue::SegQueue;
 use crossbeam_utils::atomic::AtomicCell;
+use midi_fundsp::sound_builders::*;
 use midi_fundsp::{
-    io::{get_first_midi_device, start_midi_input_thread, start_midi_output_thread_alt_tuning}, program_table, sounds::music_box, tunings::just_intonation
+    io::{get_first_midi_device, start_midi_input_thread, start_midi_output_thread_alt_tuning},
+    program_table,
+    sounds::music_box,
+    tunings::just_intonation,
 };
 use midir::MidiInput;
 use read_input::{InputBuild, shortcut::input};
@@ -22,4 +26,3 @@ fn main() -> anyhow::Result<()> {
     input::<String>().msg("Press any key to exit\n").get();
     Ok(())
 }
-

--- a/examples/msg_view_demo.rs
+++ b/examples/msg_view_demo.rs
@@ -62,7 +62,9 @@ fn run_chooser(
             0 => {
                 let program = {
                     let program_table = program_table.lock().unwrap();
-                    console_choice_from("Change synth to", &program_table, |opt| opt.0.as_str())
+                    console_choice_from("Change synth to", &program_table.entries, |opt| {
+                        opt.0.as_str()
+                    })
                 };
                 midi_msgs.push(SynthMsg::program_change(program as u8, Speaker::Both));
             }

--- a/examples/show_sound_values.rs
+++ b/examples/show_sound_values.rs
@@ -1,7 +1,7 @@
 use midi_fundsp::{SoundTestResult, sounds::options};
 
 fn main() {
-    for (name, func) in options() {
+    for (name, func) in options().to_iter_mono() {
         println!("Testing {name}");
         let result = SoundTestResult::test(func);
         result.report();

--- a/examples/stereo_demo.rs
+++ b/examples/stereo_demo.rs
@@ -2,6 +2,7 @@ use std::sync::{Arc, Mutex};
 
 use crossbeam_queue::SegQueue;
 use crossbeam_utils::atomic::AtomicCell;
+use midi_fundsp::sound_builders::*;
 use midi_fundsp::{
     io::{Speaker, SynthMsg, get_first_midi_device, start_midi_input_thread, start_output_thread},
     program_table,

--- a/src/io.rs
+++ b/src/io.rs
@@ -21,6 +21,8 @@ use midi_msg::{Channel, ChannelModeMsg, ChannelVoiceMsg, MidiMsg, SystemRealTime
 use midir::{Ignore, MidiInput, MidiInputPort};
 use read_input::{InputBuild, shortcut::input};
 use std::sync::{Arc, Mutex};
+use fundsp::prelude64::{pass, sink, U2};
+use fundsp::prelude::{join, split, U1};
 
 #[derive(Clone, Debug)]
 /// Packages a [`MidiMsg`](https://crates.io/crates/midi-msg) with a designated `Speaker` to output the sound
@@ -289,8 +291,8 @@ impl<const N: usize> StereoPlayer<N> {
 
     fn sound(&self) -> Net {
         Net::stack(
-            self.sounds[Speaker::Left.i()].sound(),
-            self.sounds[Speaker::Right.i()].sound(),
+            self.sounds[Speaker::Left.i()].sound() >> split::<U2>() >> (sink() | pass()) >> join::<U1>(),
+            self.sounds[Speaker::Right.i()].sound() >> split::<U2>() >> (pass() | sink()) >> join::<U1>(),
         )
     }
 

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,17 +1,16 @@
+use crate::sound_builders::SpeakerDef;
 use crate::{
-    control_change_from, note_velocity_from, sound_builders::ProgramTable, SharedMidiState, SynthFunc,
-    NUM_MIDI_VALUES,
+    NUM_MIDI_VALUES, SharedMidiState, SynthFunc, control_change_from, note_velocity_from,
+    sound_builders::ProgramTable,
 };
 use anyhow::{anyhow, bail};
 use bare_metal_modulo::*;
 use cpal::{
-    traits::{DeviceTrait, HostTrait, StreamTrait}, Device, FromSample, Sample, SampleFormat, SizedSample, Stream,
-    StreamConfig,
+    Device, FromSample, Sample, SampleFormat, SizedSample, Stream, StreamConfig,
+    traits::{DeviceTrait, HostTrait, StreamTrait},
 };
 use crossbeam_queue::SegQueue;
 use crossbeam_utils::atomic::AtomicCell;
-use fundsp::prelude::join;
-use fundsp::prelude64::{pass, sink, U2};
 use fundsp::{
     net::Net,
     prelude::{AudioUnit, FrameAdd, FrameMul},
@@ -21,7 +20,7 @@ use fundsp::{
 use midi_msg::ControlChange::CC;
 use midi_msg::{Channel, ChannelModeMsg, ChannelVoiceMsg, MidiMsg, SystemRealTimeMsg};
 use midir::{Ignore, MidiInput, MidiInputPort};
-use read_input::{shortcut::input, InputBuild};
+use read_input::{InputBuild, shortcut::input};
 use std::sync::{Arc, Mutex};
 
 #[derive(Clone, Debug)]
@@ -271,14 +270,25 @@ impl Speaker {
 }
 
 struct StereoPlayer<const N: usize> {
-    sounds: [MonoPlayer<N>; 2],
+    sounds: [SingleSpeakerPlayer<N>; 2],
+}
+
+fn def_to_synth(speaker: &Speaker, def: SpeakerDef) -> SynthFunc {
+    match def {
+        SpeakerDef::Mono(v) => v,
+        SpeakerDef::Stereo { right, left } => match speaker {
+            Speaker::Left => left,
+            Speaker::Right => right,
+            Speaker::Both => unreachable!(),
+        },
+    }
 }
 
 impl<const N: usize> StereoPlayer<N> {
     fn new(program_table: Arc<Mutex<ProgramTable>>) -> Self {
         let sounds = [
-            MonoPlayer::<N>::new(program_table.clone()),
-            MonoPlayer::<N>::new(program_table),
+            SingleSpeakerPlayer::<N>::new(program_table.clone(), Speaker::Left),
+            SingleSpeakerPlayer::<N>::new(program_table, Speaker::Right),
         ];
         Self { sounds }
     }
@@ -291,8 +301,8 @@ impl<const N: usize> StereoPlayer<N> {
 
     fn sound(&self) -> Net {
         Net::stack(
-            self.sounds[Speaker::Left.i()].sound() >> (sink() | pass()) >> join::<U2>(),
-            self.sounds[Speaker::Right.i()].sound() >> (pass() | sink()) >> join::<U2>(),
+            self.sounds[Speaker::Left.i()].sound(),
+            self.sounds[Speaker::Right.i()].sound(),
         )
     }
 
@@ -468,7 +478,7 @@ enum RelayedMessage {
 }
 
 #[derive(Clone)]
-struct MonoPlayer<const N: usize> {
+struct SingleSpeakerPlayer<const N: usize> {
     states: [SharedMidiState; N],
     next: ModNumC<usize, N>,
     pitch2state: [Option<usize>; NUM_MIDI_VALUES],
@@ -476,19 +486,21 @@ struct MonoPlayer<const N: usize> {
     synth_func: SynthFunc,
     master_volume: Shared,
     program_table: Arc<Mutex<ProgramTable>>,
+    speaker: Speaker,
 }
 
-impl<const N: usize> MonoPlayer<N> {
-    fn new(program_table: Arc<Mutex<ProgramTable>>) -> Self {
+impl<const N: usize> SingleSpeakerPlayer<N> {
+    fn new(program_table: Arc<Mutex<ProgramTable>>, speaker: Speaker) -> Self {
         let synth_func = {
             let program_table = program_table.lock().unwrap();
-            program_table[0].1.clone()
+            def_to_synth(&speaker, program_table.entries[0].1.clone())
         };
         Self {
             states: [(); N].map(|_| SharedMidiState::default()),
             next: ModNumC::new(0),
             pitch2state: [None; NUM_MIDI_VALUES],
             recent_pitches: [None; N],
+            speaker,
             synth_func,
             master_volume: shared(1.0),
             program_table,
@@ -530,11 +542,11 @@ impl<const N: usize> MonoPlayer<N> {
                     self.bend(*bend);
                 }
                 ChannelVoiceMsg::ProgramChange { program } => {
-                    let new_synth = {
+                    let def = {
                         let program_table = self.program_table.lock().unwrap();
-                        program_table[*program as usize].1.clone()
+                        program_table.entries[*program as usize].1.clone()
                     };
-                    self.change_synth(new_synth);
+                    self.change_synth(def);
                     return Some(RelayedMessage::SynthChange);
                 }
                 ChannelVoiceMsg::ControlChange {
@@ -594,9 +606,9 @@ impl<const N: usize> MonoPlayer<N> {
         }
     }
 
-    fn change_synth(&mut self, new_synth: SynthFunc) {
+    fn change_synth(&mut self, def: SpeakerDef) {
         self.all_sounds_off();
-        self.synth_func = new_synth;
+        self.synth_func = def_to_synth(&self.speaker, def);
     }
 
     fn bend(&mut self, bend: u16) {

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,15 +1,17 @@
 use crate::{
-    NUM_MIDI_VALUES, SharedMidiState, SynthFunc, control_change_from, note_velocity_from,
-    sound_builders::ProgramTable,
+    control_change_from, note_velocity_from, sound_builders::ProgramTable, SharedMidiState, SynthFunc,
+    NUM_MIDI_VALUES,
 };
 use anyhow::{anyhow, bail};
 use bare_metal_modulo::*;
 use cpal::{
-    Device, FromSample, Sample, SampleFormat, SizedSample, Stream, StreamConfig,
-    traits::{DeviceTrait, HostTrait, StreamTrait},
+    traits::{DeviceTrait, HostTrait, StreamTrait}, Device, FromSample, Sample, SampleFormat, SizedSample, Stream,
+    StreamConfig,
 };
 use crossbeam_queue::SegQueue;
 use crossbeam_utils::atomic::AtomicCell;
+use fundsp::prelude::join;
+use fundsp::prelude64::{pass, sink, U2};
 use fundsp::{
     net::Net,
     prelude::{AudioUnit, FrameAdd, FrameMul},
@@ -19,10 +21,8 @@ use fundsp::{
 use midi_msg::ControlChange::CC;
 use midi_msg::{Channel, ChannelModeMsg, ChannelVoiceMsg, MidiMsg, SystemRealTimeMsg};
 use midir::{Ignore, MidiInput, MidiInputPort};
-use read_input::{InputBuild, shortcut::input};
+use read_input::{shortcut::input, InputBuild};
 use std::sync::{Arc, Mutex};
-use fundsp::prelude64::{pass, sink, U2};
-use fundsp::prelude::{join, split, U1};
 
 #[derive(Clone, Debug)]
 /// Packages a [`MidiMsg`](https://crates.io/crates/midi-msg) with a designated `Speaker` to output the sound
@@ -291,8 +291,8 @@ impl<const N: usize> StereoPlayer<N> {
 
     fn sound(&self) -> Net {
         Net::stack(
-            self.sounds[Speaker::Left.i()].sound() >> split::<U2>() >> (sink() | pass()) >> join::<U1>(),
-            self.sounds[Speaker::Right.i()].sound() >> split::<U2>() >> (pass() | sink()) >> join::<U1>(),
+            self.sounds[Speaker::Left.i()].sound() >> (sink() | pass()) >> join::<U2>(),
+            self.sounds[Speaker::Right.i()].sound() >> (pass() | sink()) >> join::<U2>(),
         )
     }
 

--- a/src/sound_builders.rs
+++ b/src/sound_builders.rs
@@ -4,6 +4,7 @@ use fundsp::{
     prelude::AudioUnit,
     prelude64::{adsr_live, envelope2, moog_q},
 };
+use std::sync::Arc;
 
 use crate::{SharedMidiState, SynthFunc};
 
@@ -11,14 +12,75 @@ use crate::{SharedMidiState, SynthFunc};
 /// Convenience macro to build a `ProgramTable`. Given a sequence of tuples of `&str` objects
 /// and `SynthFunc` objects, it returns a proper `ProgramTable`.
 macro_rules! program_table {
-    ($( ($s:expr, $f:expr)),* ) => {vec![$(($s.to_owned(), Arc::new($f)),)*]}
+    ($( ($name:expr, $def:expr) ),* $(,)?) => {
+        ProgramTable::new(vec![
+            $( ($name.to_owned(), $def.into_speaker_def()) ),*
+        ])
+    };
 }
 
 /// Maximum number of entries controllable via MIDI messages in a MIDI program table.
 pub const NUM_PROGRAM_SLOTS: usize = 2_usize.pow(7);
 
 /// Convenience type alias for MIDI program tables.
-pub type ProgramTable = Vec<(String, SynthFunc)>;
+// pub type ProgramTable = Vec<(String, SynthFunc)>;
+
+#[derive(Clone)]
+pub enum SpeakerDef {
+    Mono(SynthFunc),
+    Stereo { left: SynthFunc, right: SynthFunc },
+}
+
+// Single function → Mono
+pub trait IntoSpeakerDef {
+    fn into_speaker_def(self) -> SpeakerDef;
+}
+
+// Tuple of two functions → Stereo
+// For any single function/closure that can be turned into a SynthFunc
+impl<F> IntoSpeakerDef for F
+where
+    F: Fn(&SharedMidiState) -> Box<dyn AudioUnit> + Send + Sync + 'static,
+{
+    fn into_speaker_def(self) -> SpeakerDef {
+        SpeakerDef::Mono(Arc::new(self)) // wrap into SynthFunc
+    }
+}
+
+// For a tuple of two such functions – stereo definition
+impl<L, R> IntoSpeakerDef for (L, R)
+where
+    L: Fn(&SharedMidiState) -> Box<dyn AudioUnit> + Send + Sync + 'static,
+    R: Fn(&SharedMidiState) -> Box<dyn AudioUnit> + Send + Sync + 'static,
+{
+    fn into_speaker_def(self) -> SpeakerDef {
+        SpeakerDef::Stereo {
+            left: Arc::new(self.0),
+            right: Arc::new(self.1),
+        }
+    }
+}
+pub type ProgramTableItem = (String, SpeakerDef);
+
+pub struct ProgramTable {
+    pub entries: Vec<ProgramTableItem>,
+}
+
+impl ProgramTable {
+    pub fn new(entries: Vec<ProgramTableItem>) -> Self {
+        Self { entries }
+    }
+
+    pub fn to_iter_mono(&self) -> impl Iterator<Item = (&str, SynthFunc)> {
+        self.entries.iter().map(|(name, def)| {
+            let func = match def {
+                SpeakerDef::Mono(f) => f,
+                SpeakerDef::Stereo { left, .. } => left,
+            };
+            (name.as_str(), func.clone())
+        })
+    }
+}
 
 /// Pipes a pitch into `synth`, then modulates the output volume depending on MIDI status.
 pub fn simple_sound(state: &SharedMidiState, synth: Box<dyn AudioUnit>) -> Box<dyn AudioUnit> {

--- a/src/sounds.rs
+++ b/src/sounds.rs
@@ -1,6 +1,4 @@
-use std::sync::Arc;
-
-use crate::sound_builders::{Adsr, ProgramTable, simple_sound};
+use crate::sound_builders::{Adsr, IntoSpeakerDef, ProgramTable, simple_sound};
 use crate::{SharedMidiState, program_table};
 use fundsp::net::Net;
 use fundsp::prelude::{


### PR DESCRIPTION
added a way to provide different functions to left and right channels, this includes new enums and types, with some refactoring of terms and the program table. This introduces some breaking changes to the infrastructure (the examples are fixed accordingly, of course) , so if you're uncomfortable with that I can just continue with my fork for my own synth :)

This does allow for richer sounds and the option to choose different L and R channels directly from a program table, which I think is cool!