### PR TITLE
Voice stealing with configuration struct

### DIFF
--- a/examples/basic_demo.rs
+++ b/examples/basic_demo.rs
@@ -15,7 +15,7 @@ fn main() -> anyhow::Result<()> {
     let midi_msgs = Arc::new(SegQueue::new());
     let quit = Arc::new(AtomicCell::new(false));
     start_input_thread(midi_msgs.clone(), midi_in, in_port, quit.clone());
-    start_output_thread::<10>(midi_msgs, Arc::new(Mutex::new(options())));
+    start_output_thread::<10>(midi_msgs, Arc::new(Mutex::new(options())), None);
     input::<String>().msg("Press any key to exit\n").get();
     Ok(())
 }

--- a/examples/cc_demo.rs
+++ b/examples/cc_demo.rs
@@ -25,6 +25,7 @@ fn main() -> anyhow::Result<()> {
         outgoing_msgs,
         Arc::new(Mutex::new(program_table![("Music Box", music_box::<7>)])),
         just_intonation,
+        None,
     );
     input::<String>().msg("Press Enter to exit\n").get();
     Ok(())

--- a/examples/choice_demo.rs
+++ b/examples/choice_demo.rs
@@ -22,7 +22,7 @@ fn main() -> anyhow::Result<()> {
         while reset.load() {}
         start_input_thread(midi_msgs.clone(), midi_in, in_port, reset.clone());
         let program_table = Arc::new(Mutex::new(options()));
-        start_output_thread::<10>(midi_msgs.clone(), program_table.clone());
+        start_output_thread::<10>(midi_msgs.clone(), program_table.clone(), None);
         run_chooser(midi_msgs, program_table.clone(), reset.clone(), &mut quit);
     }
     Ok(())

--- a/examples/just_tempered_demo.rs
+++ b/examples/just_tempered_demo.rs
@@ -3,6 +3,7 @@ use std::sync::{Arc, Mutex};
 use crossbeam_queue::SegQueue;
 use crossbeam_utils::atomic::AtomicCell;
 use midi_fundsp::sound_builders::*;
+use midi_fundsp::config::{Config, VoiceStealingConfig};
 use midi_fundsp::{
     io::{get_first_midi_device, start_midi_input_thread, start_midi_output_thread_alt_tuning},
     program_table,
@@ -13,6 +14,8 @@ use midir::MidiInput;
 use read_input::{InputBuild, shortcut::input};
 
 fn main() -> anyhow::Result<()> {
+    let mut config = Config::default();
+    config.voice_stealing = VoiceStealingConfig::Latest;
     let mut midi_in = MidiInput::new("midir reading input")?;
     let in_port = get_first_midi_device(&mut midi_in)?;
     let midi_msgs = Arc::new(SegQueue::new());
@@ -22,6 +25,7 @@ fn main() -> anyhow::Result<()> {
         midi_msgs,
         Arc::new(Mutex::new(program_table![("Music Box", music_box::<7>)])),
         just_intonation,
+        Some(config),
     );
     input::<String>().msg("Press Enter to exit\n").get();
     Ok(())

--- a/examples/legato_2_voices_example.rs
+++ b/examples/legato_2_voices_example.rs
@@ -3,26 +3,28 @@ use std::sync::{Arc, Mutex};
 use crossbeam_queue::SegQueue;
 use crossbeam_utils::atomic::AtomicCell;
 use midi_fundsp::sound_builders::*;
+use midi_fundsp::config::{Config, VoiceStealingConfig};
 use midi_fundsp::{
-    io::{get_first_midi_device, start_midi_input_thread, start_midi_output_thread_alt_tuning},
+    io::{get_first_midi_device, start_midi_input_thread},
     program_table,
-    sounds::music_box,
-    tunings::just_intonation,
+    sounds::moog_organ
 };
 use midir::MidiInput;
 use read_input::{InputBuild, shortcut::input};
+use midi_fundsp::io::start_midi_output_thread;
 
 fn main() -> anyhow::Result<()> {
+    let mut config = Config::default();
+    config.voice_stealing = VoiceStealingConfig::Latest;
     let mut midi_in = MidiInput::new("midir reading input")?;
     let in_port = get_first_midi_device(&mut midi_in)?;
     let midi_msgs = Arc::new(SegQueue::new());
     let quit = Arc::new(AtomicCell::new(false));
     start_midi_input_thread(midi_msgs.clone(), midi_in, in_port, quit.clone());
-    start_midi_output_thread_alt_tuning::<10>(
+    start_midi_output_thread::<2>(
         midi_msgs,
-        Arc::new(Mutex::new(program_table![("Music Box", music_box::<7>)])),
-        just_intonation,
-        None
+        Arc::new(Mutex::new(program_table![("Organ", moog_organ)])),
+        Some(config),
     );
     input::<String>().msg("Press Enter to exit\n").get();
     Ok(())

--- a/examples/legato_2_voices_example.rs
+++ b/examples/legato_2_voices_example.rs
@@ -3,7 +3,7 @@ use std::sync::{Arc, Mutex};
 use crossbeam_queue::SegQueue;
 use crossbeam_utils::atomic::AtomicCell;
 use midi_fundsp::sound_builders::*;
-use midi_fundsp::config::{Config, VoiceStealingConfig};
+use midi_fundsp::config::{Config, FreeVoiceStrategy, VoiceStealingConfig};
 use midi_fundsp::{
     io::{get_first_midi_device, start_midi_input_thread},
     program_table,
@@ -15,7 +15,8 @@ use midi_fundsp::io::start_midi_output_thread;
 
 fn main() -> anyhow::Result<()> {
     let mut config = Config::default();
-    config.voice_stealing = VoiceStealingConfig::Last;
+    config.voice_stealing = VoiceStealingConfig::LegatoLast;
+    config.voice_release = FreeVoiceStrategy::ReleaseOnZero;
     let mut midi_in = MidiInput::new("midir reading input")?;
     let in_port = get_first_midi_device(&mut midi_in)?;
     let midi_msgs = Arc::new(SegQueue::new());

--- a/examples/legato_2_voices_example.rs
+++ b/examples/legato_2_voices_example.rs
@@ -15,7 +15,7 @@ use midi_fundsp::io::start_midi_output_thread;
 
 fn main() -> anyhow::Result<()> {
     let mut config = Config::default();
-    config.voice_stealing = VoiceStealingConfig::Latest;
+    config.voice_stealing = VoiceStealingConfig::Last;
     let mut midi_in = MidiInput::new("midir reading input")?;
     let in_port = get_first_midi_device(&mut midi_in)?;
     let midi_msgs = Arc::new(SegQueue::new());

--- a/examples/midi_only_demo.rs
+++ b/examples/midi_only_demo.rs
@@ -15,7 +15,7 @@ fn main() -> anyhow::Result<()> {
     let midi_msgs = Arc::new(SegQueue::new());
     let quit = Arc::new(AtomicCell::new(false));
     start_midi_input_thread(midi_msgs.clone(), midi_in, in_port, quit.clone());
-    start_midi_output_thread::<10>(midi_msgs, Arc::new(Mutex::new(options())));
+    start_midi_output_thread::<10>(midi_msgs, Arc::new(Mutex::new(options())), None);
     input::<String>().msg("Press any key to exit\n").get();
     Ok(())
 }

--- a/examples/msg_view_demo.rs
+++ b/examples/msg_view_demo.rs
@@ -23,7 +23,7 @@ fn main() -> anyhow::Result<()> {
         while reset.load() {}
         start_input_thread(incoming_msgs.clone(), midi_in, in_port, reset.clone());
         let program_table = Arc::new(Mutex::new(options()));
-        start_output_thread::<10>(outgoing_msgs.clone(), program_table.clone());
+        start_output_thread::<10>(outgoing_msgs.clone(), program_table.clone(), None);
         run_midi_show_thread(incoming_msgs, outgoing_msgs.clone());
         run_chooser(
             outgoing_msgs,

--- a/examples/note_velocity_demo.rs
+++ b/examples/note_velocity_demo.rs
@@ -18,7 +18,7 @@ fn main() -> anyhow::Result<()> {
     let outputs = Arc::new(SegQueue::new());
     start_input_thread(inputs.clone(), midi_in, in_port, reset.clone());
     let program_table = Arc::new(Mutex::new(options()));
-    start_output_thread::<10>(outputs.clone(), program_table.clone());
+    start_output_thread::<10>(outputs.clone(), program_table.clone(), None);
     std::thread::spawn(move || {
         loop {
             if let Some(msg) = inputs.pop() {

--- a/examples/stereo_demo.rs
+++ b/examples/stereo_demo.rs
@@ -24,7 +24,7 @@ fn main() -> anyhow::Result<()> {
     start_midi_input_thread(midi_msgs.clone(), midi_in, in_port, quit.clone());
     let stereo_msgs = Arc::new(SegQueue::new());
     stereo_msgs.push(SynthMsg::program_change(1, Speaker::Left));
-    start_output_thread::<10>(stereo_msgs.clone(), stereo_table);
+    start_output_thread::<10>(stereo_msgs.clone(), stereo_table, None);
 
     println!("Play notes at will.");
     println!(

--- a/examples/well_tempered_demo.rs
+++ b/examples/well_tempered_demo.rs
@@ -20,6 +20,7 @@ fn main() -> anyhow::Result<()> {
         midi_msgs,
         Arc::new(Mutex::new(options())),
         well_temperament,
+        None,
     );
     input::<String>().msg("Press any key to exit\n").get();
     Ok(())

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,20 @@
+/// Determines whether to steal the oldest or latest notes
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub enum VoiceStealingConfig {
+    Oldest,
+    Latest,
+}
+
+/// Configuration block for extra features
+#[derive(Debug, Clone, PartialEq)]
+pub struct Config {
+    pub voice_stealing: VoiceStealingConfig,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            voice_stealing: VoiceStealingConfig::Oldest,
+        }
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,20 +1,37 @@
-/// Determines whether to steal the oldest or latest notes
+/// Determines the voice stealing strategy:
+/// LegatoOldest: Keep envelope and steal the oldest voice
+/// LegatoLast: either oldest or latest voice
+/// LastRetrigger: steal last voice and re-trigger current
+/// OldestRetrigger: steal latest voice and re-trigger current
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum VoiceStealingConfig {
-    Oldest,
-    Last,
+    LegatoOldest,
+    LegatoLast,
+    OldestRetrigger,
+    LastRetrigger,
+    // todo: quietest?
+}
+
+/// determine if voices are freed by instrument ADSR or by being at zero volume
+/// release on zero is a bit costlier but allows for 0.0 release sounds to play more naturally
+ #[derive(Debug, Copy, Clone, PartialEq)]
+pub enum FreeVoiceStrategy {
+    FollowADSR,
+    ReleaseOnZero
 }
 
 /// Configuration block for extra features
 #[derive(Debug, Clone, PartialEq)]
 pub struct Config {
     pub voice_stealing: VoiceStealingConfig,
+    pub voice_release: FreeVoiceStrategy,
 }
 
 impl Default for Config {
     fn default() -> Self {
         Self {
-            voice_stealing: VoiceStealingConfig::Oldest,
+            voice_stealing: VoiceStealingConfig::LegatoOldest,
+            voice_release: FreeVoiceStrategy::FollowADSR,
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,7 +2,7 @@
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum VoiceStealingConfig {
     Oldest,
-    Latest,
+    Last,
 }
 
 /// Configuration block for extra features

--- a/src/config.rs
+++ b/src/config.rs
@@ -26,7 +26,8 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             voice_stealing: VoiceStealingConfig::LegatoOldest,
-            voice_release: FreeVoiceStrategy::FollowADSR,
+            voice_release: FreeVoiceStrategy::ReleaseOnZero,
         }
     }
+
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,19 +1,14 @@
 /// Determines the voice stealing strategy:
 /// LegatoOldest: Keep envelope and steal the oldest voice
 /// LegatoLast: either oldest or latest voice
-/// LastRetrigger: steal last voice and re-trigger current
-/// OldestRetrigger: steal latest voice and re-trigger current
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum VoiceStealingConfig {
     LegatoOldest,
     LegatoLast,
-    OldestRetrigger,
-    LastRetrigger,
-    // todo: quietest?
 }
 
-/// determine if voices are freed by instrument ADSR or by being at zero volume
-/// release on zero is a bit costlier but allows for 0.0 release sounds to play more naturally
+/// Determine if voices are freed from current voices queue by instrument ADSR or by being at zero volume.
+/// Release on zero is a bit costlier but allows for 0.0 release sounds to play better.
  #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum FreeVoiceStrategy {
     FollowADSR,

--- a/src/io.rs
+++ b/src/io.rs
@@ -22,7 +22,7 @@ use midi_msg::{Channel, ChannelModeMsg, ChannelVoiceMsg, MidiMsg, SystemRealTime
 use midir::{Ignore, MidiInput, MidiInputPort};
 use read_input::{InputBuild, shortcut::input};
 use std::sync::{Arc, Mutex};
-use crate::config::{Config, VoiceStealingConfig};
+use crate::config::{Config, FreeVoiceStrategy, VoiceStealingConfig};
 
 #[derive(Clone, Debug)]
 /// Packages a [`MidiMsg`](https://crates.io/crates/midi-msg) with a designated `Speaker` to output the sound
@@ -305,13 +305,12 @@ impl<const N: usize> StereoPlayer<N> {
         }
     }
 
-    fn sound(&self) -> Net {
+    fn sound(&mut self) -> Net {
         Net::stack(
             self.sounds[Speaker::Left.i()].sound(),
             self.sounds[Speaker::Right.i()].sound(),
         )
     }
-
     fn run_output(&mut self, midi_msgs: Arc<SegQueue<SynthMsg>>) -> anyhow::Result<()> {
         let host = cpal::default_host();
         let device = host
@@ -391,7 +390,7 @@ impl<const N: usize> StereoPlayer<N> {
     }
 
     fn get_stream<T: Sample + SizedSample + FromSample<f32>>(
-        &self,
+        &mut self,
         config: &StreamConfig,
         device: &Device,
     ) -> anyhow::Result<Stream> {
@@ -412,6 +411,11 @@ impl<const N: usize> StereoPlayer<N> {
                 None,
             )
             .or_else(|err| bail!("{err:?}"))
+    }
+
+    pub fn set_new_config(&mut self, config: Config) {
+        self.sounds[Speaker::Right.i()].set_new_config(config.clone());
+        self.sounds[Speaker::Left.i()].set_new_config(config);
     }
 }
 
@@ -521,10 +525,28 @@ impl<const N: usize> SingleSpeakerPlayer<N> {
         }
     }
 
-    fn sound(&self) -> Net {
+    fn set_new_config(&mut self, new_config: Config) {
+        self.config = new_config;
+    }
+
+    fn nullify_zero_value_notes(&mut self, sound: &mut Net, i:usize) -> bool {
+        let sample = sound.get_mono();
+        if sample == 0_f32 {
+            self.release(i);
+            return true
+        }
+        false
+    }
+    fn sound(&mut self) -> Net {
         let mut sound = Net::wrap(self.sound_at(0));
+        if self.config.voice_release == FreeVoiceStrategy::ReleaseOnZero {
+            self.nullify_zero_value_notes(&mut sound, 0);
+        }
         for i in 1..N {
             sound = Net::binary(sound, Net::wrap(self.sound_at(i)), FrameAdd::new());
+            if self.config.voice_release == FreeVoiceStrategy::ReleaseOnZero {
+                self.nullify_zero_value_notes(&mut sound, 0);
+            }
         }
         Net::binary(
             sound,
@@ -588,11 +610,10 @@ impl<const N: usize> SingleSpeakerPlayer<N> {
             }
         }
         self.next = match self.config.voice_stealing {
-            VoiceStealingConfig::Oldest => self.next,
-            VoiceStealingConfig::Last => ModNumC::new(self.next.a() + (N -1))
+            VoiceStealingConfig::LegatoOldest => self.next,
+            VoiceStealingConfig::LegatoLast => ModNumC::new(self.next.a() + (N -1)),
+            VoiceStealingConfig::LastRetrigger | VoiceStealingConfig::OldestRetrigger => todo!()
         };
-        self.pitch2state[self.recent_pitches[self.next.a()].unwrap() as usize] = None;
-        self.release(self.next.a());
         self.claim_state(self.next)
     }
 
@@ -605,7 +626,7 @@ impl<const N: usize> SingleSpeakerPlayer<N> {
     fn on(&mut self, pitch: u8, velocity: u8) {
         self.master_volume.set_value(1.0);
         let selected = self.find_next_state();
-        self.states[selected].on(pitch, velocity);
+        self.states[selected].note_on(pitch, velocity);
         self.pitch2state[pitch as usize] = Some(selected);
         self.recent_pitches[selected] = Some(pitch);
     }
@@ -636,7 +657,7 @@ impl<const N: usize> SingleSpeakerPlayer<N> {
 
     fn release(&mut self, i: usize) {
         self.recent_pitches[i] = None;
-        self.states[i].off();
+        self.states[i].note_off();
     }
 
     fn release_all(&mut self) {

--- a/src/io.rs
+++ b/src/io.rs
@@ -22,6 +22,7 @@ use midi_msg::{Channel, ChannelModeMsg, ChannelVoiceMsg, MidiMsg, SystemRealTime
 use midir::{Ignore, MidiInput, MidiInputPort};
 use read_input::{InputBuild, shortcut::input};
 use std::sync::{Arc, Mutex};
+use crate::config::{Config, VoiceStealingConfig};
 
 #[derive(Clone, Debug)]
 /// Packages a [`MidiMsg`](https://crates.io/crates/midi-msg) with a designated `Speaker` to output the sound
@@ -185,9 +186,10 @@ fn input_callback<M: Send + 'static, F: Send + 'static + Fn(MidiMsg) -> M>(
 pub fn start_output_thread<const N: usize>(
     midi_msgs: Arc<SegQueue<SynthMsg>>,
     program_table: Arc<Mutex<ProgramTable>>,
+    config: Option<Config>,
 ) {
     std::thread::spawn(move || {
-        let mut player = StereoPlayer::<N>::new(program_table);
+        let mut player = StereoPlayer::<N>::new(program_table, config);
         player.run_output(midi_msgs).unwrap();
     });
 }
@@ -205,8 +207,9 @@ pub fn start_output_thread<const N: usize>(
 pub fn start_midi_output_thread<const N: usize>(
     midi_msgs: Arc<SegQueue<MidiMsg>>,
     program_table: Arc<Mutex<ProgramTable>>,
+    config: Option<Config>,
 ) {
-    inner_start_output_thread(midi_msgs, StereoPlayer::<N>::new(program_table));
+    inner_start_output_thread(midi_msgs,  StereoPlayer::<N>::new(program_table, config));
 }
 
 /// Plays sounds according to `MidiMsg` objects received in the `midi_msgs` queue. Synthesizer sounds may be selected with
@@ -226,8 +229,9 @@ pub fn start_midi_output_thread_alt_tuning<const N: usize>(
     midi_msgs: Arc<SegQueue<MidiMsg>>,
     program_table: Arc<Mutex<ProgramTable>>,
     midi_to_hz: fn(f32) -> f32,
+    config: Option<Config>,
 ) {
-    let mut player = StereoPlayer::<N>::new(program_table);
+    let mut player =  StereoPlayer::<N>::new(program_table, config);
     player.set_midi_to_hz(midi_to_hz);
     inner_start_output_thread(midi_msgs, player);
 }
@@ -254,6 +258,18 @@ fn inner_start_output_thread<const N: usize>(
     });
 }
 
+/// Convenience method for extracting a SynthFunc from a Speaker-Definition Enum based on a selected speaker.
+fn def_to_synth(speaker: &Speaker, def: SpeakerDef) -> SynthFunc {
+    match def {
+        SpeakerDef::Mono(v) => v,
+        SpeakerDef::Stereo { right, left } => match speaker {
+            Speaker::Left => left,
+            Speaker::Right => right,
+            Speaker::Both => unreachable!(),
+        },
+    }
+}
+
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 /// Represents whether a sound should go to the left, right, or both speakers.
 pub enum Speaker {
@@ -273,23 +289,12 @@ struct StereoPlayer<const N: usize> {
     sounds: [SingleSpeakerPlayer<N>; 2],
 }
 
-/// Convenience method for extracting a SynthFunc from a Speaker-Definition Enum based on a selected speaker.
-fn def_to_synth(speaker: &Speaker, def: SpeakerDef) -> SynthFunc {
-    match def {
-        SpeakerDef::Mono(v) => v,
-        SpeakerDef::Stereo { right, left } => match speaker {
-            Speaker::Left => left,
-            Speaker::Right => right,
-            Speaker::Both => unreachable!(),
-        },
-    }
-}
-
 impl<const N: usize> StereoPlayer<N> {
-    fn new(program_table: Arc<Mutex<ProgramTable>>) -> Self {
+    fn new(program_table: Arc<Mutex<ProgramTable>>, config: Option<Config>) -> Self {
+        let config = config.unwrap_or_else(|| Config::default());
         let sounds = [
-            SingleSpeakerPlayer::<N>::new(program_table.clone(), Speaker::Left),
-            SingleSpeakerPlayer::<N>::new(program_table, Speaker::Right),
+            SingleSpeakerPlayer::<N>::new(program_table.clone(), Speaker::Left, config.clone()),
+            SingleSpeakerPlayer::<N>::new(program_table, Speaker::Right, config.clone()),
         ];
         Self { sounds }
     }
@@ -488,10 +493,11 @@ struct SingleSpeakerPlayer<const N: usize> {
     master_volume: Shared,
     program_table: Arc<Mutex<ProgramTable>>,
     speaker: Speaker,
+    config: Config
 }
 
 impl<const N: usize> SingleSpeakerPlayer<N> {
-    fn new(program_table: Arc<Mutex<ProgramTable>>, speaker: Speaker) -> Self {
+    fn new(program_table: Arc<Mutex<ProgramTable>>, speaker: Speaker, config: Config) -> Self {
         let synth_func = {
             let program_table = program_table.lock().unwrap();
             def_to_synth(&speaker, program_table.entries[0].1.clone())
@@ -505,6 +511,7 @@ impl<const N: usize> SingleSpeakerPlayer<N> {
             synth_func,
             master_volume: shared(1.0),
             program_table,
+            config,
         }
     }
 
@@ -580,6 +587,10 @@ impl<const N: usize> SingleSpeakerPlayer<N> {
                 return self.claim_state(i);
             }
         }
+        self.next = match self.config.voice_stealing {
+            VoiceStealingConfig::Oldest => self.next,
+            VoiceStealingConfig::Latest => ModNumC::new(self.next.a() + (N -1))
+        };
         self.pitch2state[self.recent_pitches[self.next.a()].unwrap() as usize] = None;
         self.release(self.next.a());
         self.claim_state(self.next)

--- a/src/io.rs
+++ b/src/io.rs
@@ -585,7 +585,7 @@ impl<const N: usize> SingleSpeakerPlayer<N> {
                     for state in self.states.iter_mut() {
                         state.set_control_change(*control, *value);
                     }
-                    return Some(RelayedMessage::SynthChange);
+                    // return Some(RelayedMessage::SynthChange);
                 }
                 _ => {}
             },

--- a/src/io.rs
+++ b/src/io.rs
@@ -612,7 +612,6 @@ impl<const N: usize> SingleSpeakerPlayer<N> {
         self.next = match self.config.voice_stealing {
             VoiceStealingConfig::LegatoOldest => self.next,
             VoiceStealingConfig::LegatoLast => ModNumC::new(self.next.a() + (N -1)),
-            VoiceStealingConfig::LastRetrigger | VoiceStealingConfig::OldestRetrigger => todo!()
         };
         self.claim_state(self.next)
     }

--- a/src/io.rs
+++ b/src/io.rs
@@ -589,7 +589,7 @@ impl<const N: usize> SingleSpeakerPlayer<N> {
         }
         self.next = match self.config.voice_stealing {
             VoiceStealingConfig::Oldest => self.next,
-            VoiceStealingConfig::Latest => ModNumC::new(self.next.a() + (N -1))
+            VoiceStealingConfig::Last => ModNumC::new(self.next.a() + (N -1))
         };
         self.pitch2state[self.recent_pitches[self.next.a()].unwrap() as usize] = None;
         self.release(self.next.a());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,8 +174,8 @@ impl SharedMidiState {
         var(&self.control_change[idx])
     }
 
-    /// Encodes a MIDI `Note On` event.
-    pub fn on(&self, pitch: u8, velocity: u8) {
+    /// Encodes a MIDI `Note On` event as a positive gate signal
+    pub fn note_on(&self, pitch: u8, velocity: u8) {
         self.pitch.set_value((self.midi_to_hz)(pitch as f32));
         self.velocity
             .set_value(velocity as f32 / MAX_MIDI_VALUE as f32);
@@ -183,7 +183,7 @@ impl SharedMidiState {
     }
 
     /// Encodes a MIDI `Note Off` event.
-    pub fn off(&self) {
+    pub fn note_off(&self) {
         self.control.set_value(CONTROL_OFF);
     }
 
@@ -300,7 +300,7 @@ impl SoundTestResult {
         sound.set_sample_rate(SAMPLE_RATE);
         let mut next_value = move || sound.get_mono();
         let start = Instant::now();
-        state.on(60, 127);
+        state.note_on(60, 127);
         while start.elapsed().as_secs_f64() < DURATION {
             result.add_value(next_value());
             std::thread::sleep(Duration::from_secs_f64(SLEEP_TIME));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,7 @@ pub mod io;
 pub mod sound_builders;
 pub mod sounds;
 pub mod tunings;
+pub mod config;
 
 use std::fmt::Debug;
 use std::sync::Arc;

--- a/src/sounds.rs
+++ b/src/sounds.rs
@@ -343,10 +343,10 @@ pub fn wide_chorus_guitarish_r(state: &SharedMidiState) -> Box<dyn AudioUnit> {
 /// Something between a celesta and a prepared-piano with filter cutoff mapped to specified midi CC constant
 pub fn music_box<const CC: usize>(state: &SharedMidiState) -> Box<dyn AudioUnit> {
     let synth_adsr = Adsr {
-        attack: 0.002,
-        decay: 0.0,
-        sustain: 1.0,
-        release: 0.6,
+        attack: 0.003,
+        decay: 0.6,
+        sustain: 0.8,
+        release: 0.01,
     };
     let a1 = 0.600;
     let a2 = 0.350;
@@ -355,7 +355,7 @@ pub fn music_box<const CC: usize>(state: &SharedMidiState) -> Box<dyn AudioUnit>
     let gate = state.control_var();
 
     let modes = mul(1.000)
-        >> sine() * (gate.clone() >> adsr_live(0.002, 0.5, 0.0, synth_adsr.release))
+        >> sine() * (gate.clone() >> adsr_live(0.002, 0.5, 0.3, synth_adsr.release))
         & (mul(2.756) >> sine() * a1)
             * (gate.clone() >> adsr_live(0.002, 0.5 / 2.0, 0.0, synth_adsr.release))
         & (mul(5.404) >> sine() * a2)

--- a/src/sounds.rs
+++ b/src/sounds.rs
@@ -343,10 +343,10 @@ pub fn wide_chorus_guitarish_r(state: &SharedMidiState) -> Box<dyn AudioUnit> {
 /// Something between a celesta and a prepared-piano with filter cutoff mapped to specified midi CC constant
 pub fn music_box<const CC: usize>(state: &SharedMidiState) -> Box<dyn AudioUnit> {
     let synth_adsr = Adsr {
-        attack: 0.003,
-        decay: 0.6,
-        sustain: 0.8,
-        release: 0.01,
+        attack: 0.002,
+        decay: 0.0,
+        sustain: 1.0,
+        release: 0.6,
     };
     let a1 = 0.600;
     let a2 = 0.350;


### PR DESCRIPTION
1. I ended up implementing only legato stealing as re-triggering seems to require a deeper refactoring. 
2. I implemented a configurable mechanism of freeing notes when they reach 0 gain, this can help with plucky sounds - as they currently don't play nicely if you reach the voice limit and still have some keys pressed down.
3. I also edited some naming conventions that made it a bit confusing for me to understand the flow at first glance.
4. why was self.release(self.next.a()) removed? the note never has a chance to receive a control off anyway - which is what we want for legato. If we want a re-trigger we need to schedule a release and the starting of a new note - which seems to be beyond the current PRs agreed scope.

I believe we can add more functionality in the future via configurations - this also opens the door for per-program configurations.

What was left out:
I think the voice management can be less convoluted with a VecDeque, we can further discuss in https://github.com/gjf2a/midi_fundsp/issues/7